### PR TITLE
fix: validate q_ (quality) parameter range (1-100)

### DIFF
--- a/src/transform.test.ts
+++ b/src/transform.test.ts
@@ -1,0 +1,13 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { parseTransformString } from "./transform.js";
+
+test("parseTransformString validates quality parameter q_", () => {
+  assert.strictEqual(parseTransformString("q_80").quality, 80);
+  assert.strictEqual(parseTransformString("q_1").quality, 1);
+  assert.strictEqual(parseTransformString("q_100").quality, 100);
+  assert.strictEqual(parseTransformString("q_abc").quality, undefined);
+  assert.strictEqual(parseTransformString("q_0").quality, undefined);
+  assert.strictEqual(parseTransformString("q_101").quality, undefined);
+  assert.strictEqual(parseTransformString("q_-10").quality, undefined);
+});

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -59,9 +59,14 @@ export function parseTransformString(raw: string): ParsedTransform {
           result.format = value as ParsedTransform["format"];
         }
         break;
-      case "q":
-        result.quality = parseInt(value, 10);
+      case "q": {
+        // Quality, as an integer from 1 to 100.
+        const quality = parseInt(value, 10);
+        if (!Number.isNaN(quality) && quality >= 1 && quality <= 100) {
+          result.quality = quality;
+        }
         break;
+      }
       case "c":
         if (value === "fill" || value === "fit") {
           result.crop = value;


### PR DESCRIPTION
Fixes #2.

### Summary
In `src/transform.ts`, the `q_` (quality) parameter was parsed without checking if the value is a valid number within the 1-100 range. Invalid or non-numeric quality parameters (such as `q_abc` or `q_9999`) caused Sharp to throw an internal error, leading `applyTransform` to trigger the passthrough fallback and serve the un-transformed image.

This PR updates `q_` parsing to align with `ws_` and `wo_` validation rules: only integers between 1 and 100 are accepted. Out-of-bounds or non-numeric inputs are ignored, falling back to the default quality setting of 80.

---
Generated from a bounded immutable repository snapshot by PARS-Agent using Gemini 3.6 Flash. Tests listed above are recommendations unless GitHub checks report otherwise.
